### PR TITLE
xx should be divided by rho after addition with rho*I

### DIFF
--- a/src/SLOPE.cpp
+++ b/src/SLOPE.cpp
@@ -202,10 +202,10 @@ List cppSLOPE(T& x, mat& y, const List control)
             std::pow(eigval.max(), 1/3)*std::pow(lambda.max()*alpha(k), 2/3);
         }
 
+        xx.diag() += rho;
+        
         if (n < p)
           xx /= rho;
-
-        xx.diag() += rho;
 
         U = chol(xx);
         L = U.t();


### PR DESCRIPTION
Looks like the order is incorrect currently.