### PR TITLE
adding only_noneros argument to coef()

### DIFF
--- a/R/coef.R
+++ b/R/coef.R
@@ -28,7 +28,7 @@ coef.SLOPE <- function(object,
                        exact = FALSE,
                        simplify = TRUE,
                        sigma,
-                       only_nonzeros = TRUE,
+                       only_nonzeros = FALSE,
                        ...) {
 
   if (!missing(sigma)) {
@@ -62,7 +62,7 @@ coef.SLOPE <- function(object,
     beta <- drop(beta)
 
   if(only_nonzeros)
-    beta = apply(beta, 1, function(vec) vec[which(vec != 0, arr.ind = TRUE)])
+    beta = apply(beta, 2, function(vec) vec[which(vec != 0, arr.ind = TRUE)])
 
   beta
 }

--- a/R/coef.R
+++ b/R/coef.R
@@ -28,6 +28,7 @@ coef.SLOPE <- function(object,
                        exact = FALSE,
                        simplify = TRUE,
                        sigma,
+                       only_nonzeros = TRUE,
                        ...) {
 
   if (!missing(sigma)) {
@@ -59,6 +60,9 @@ coef.SLOPE <- function(object,
 
   if (simplify)
     beta <- drop(beta)
+
+  if(only_nonzeros)
+    beta = apply(beta, 1, function(vec) vec[which(vec != 0, arr.ind = TRUE)])
 
   beta
 }

--- a/R/coef.R
+++ b/R/coef.R
@@ -61,8 +61,12 @@ coef.SLOPE <- function(object,
   if (simplify)
     beta <- drop(beta)
 
-  if(only_nonzeros)
-    beta = apply(beta, 2, function(vec) vec[which(vec != 0, arr.ind = TRUE)])
+  if(only_nonzeros) {
+    if(is.null(dim(beta)))
+      beta = beta[which(beta != 0, arr.ind = TRUE)]
+    else
+      beta = apply(beta, 1, function(vec) vec[which(vec != 0, arr.ind = TRUE)])
+  }
 
   beta
 }


### PR DESCRIPTION
Adding the argument 'only_nonzeros' to coef() to print only nonzero coefficients. GSoC 2021 task for the project 'Adding Adaptive Bayesian SLOPE (ABSLOPE) to the SLOPE Package'.