### PR TITLE
feat: enable use of `big.matrix` objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -90,10 +90,13 @@ Depends:
 Imports:
     Matrix,
     methods,
-    Rcpp
+    Rcpp,
+    bigmemory
 LinkingTo:
     Rcpp,
-    RcppEigen (>= 0.3.4.0.0)
+    RcppEigen (>= 0.3.4.0.0),
+    BH,
+    bigmemory
 Suggests:
     covr,
     knitr,

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -17,6 +17,10 @@ denseSLOPE <- function(x, y, control) {
     .Call(`_SLOPE_denseSLOPE`, x, y, control)
 }
 
+bigSLOPE <- function(x, y, control) {
+    .Call(`_SLOPE_bigSLOPE`, x, y, control)
+}
+
 cvSparseCpp <- function(x, y, cv_args, model_args) {
     .Call(`_SLOPE_cvSparseCpp`, x, y, cv_args, model_args)
 }

--- a/R/SLOPE.R
+++ b/R/SLOPE.R
@@ -454,8 +454,20 @@ SLOPE <- function(
   alpha <- control$alpha
 
   is_sparse <- inherits(x, "sparseMatrix")
+  is_big_matrix <- inherits(x, "big.matrix")
 
-  fitSLOPE <- if (is_sparse) sparseSLOPE else denseSLOPE
+  fitSLOPE <- if (is_sparse) {
+    sparseSLOPE
+  } else if (is_big_matrix) {
+    bigSLOPE
+  } else {
+    denseSLOPE
+  }
+
+  if (is_big_matrix) {
+    x <- x@address
+  }
+
   fit <- fitSLOPE(x, y, control)
 
   lambda <- fit$lambda
@@ -606,6 +618,7 @@ processSlopeArgs <- function(
 
   # convert sparse x to dgCMatrix class from package Matrix.
   is_sparse <- inherits(x, "sparseMatrix")
+  is_big_matrix <- inherits(x, "big.matrix")
 
   if (NROW(y) == 0) {
     stop("`y` is empty")
@@ -617,7 +630,7 @@ processSlopeArgs <- function(
 
   if (is_sparse) {
     x <- as_dgCMatrix(x)
-  } else {
+  } else if (!is_big_matrix) {
     x <- as.matrix(x)
   }
 

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,8 @@
                     SparseM
                     caret
                     e1071
+                    bigmemory
+                    BH
                   ];
                 }
               );

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -65,6 +65,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// bigSLOPE
+Rcpp::List bigSLOPE(SEXP x, const Eigen::MatrixXd& y, const Rcpp::List& control);
+RcppExport SEXP _SLOPE_bigSLOPE(SEXP xSEXP, SEXP ySEXP, SEXP controlSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type x(xSEXP);
+    Rcpp::traits::input_parameter< const Eigen::MatrixXd& >::type y(ySEXP);
+    Rcpp::traits::input_parameter< const Rcpp::List& >::type control(controlSEXP);
+    rcpp_result_gen = Rcpp::wrap(bigSLOPE(x, y, control));
+    return rcpp_result_gen;
+END_RCPP
+}
 // cvSparseCpp
 Rcpp::List cvSparseCpp(Eigen::SparseMatrix<double>& x, const Eigen::MatrixXd& y, const Rcpp::List& cv_args, const Rcpp::List& model_args);
 RcppExport SEXP _SLOPE_cvSparseCpp(SEXP xSEXP, SEXP ySEXP, SEXP cv_argsSEXP, SEXP model_argsSEXP) {
@@ -99,6 +112,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_SLOPE_lambdaSequenceCpp", (DL_FUNC) &_SLOPE_lambdaSequenceCpp, 6},
     {"_SLOPE_sparseSLOPE", (DL_FUNC) &_SLOPE_sparseSLOPE, 3},
     {"_SLOPE_denseSLOPE", (DL_FUNC) &_SLOPE_denseSLOPE, 3},
+    {"_SLOPE_bigSLOPE", (DL_FUNC) &_SLOPE_bigSLOPE, 3},
     {"_SLOPE_cvSparseCpp", (DL_FUNC) &_SLOPE_cvSparseCpp, 4},
     {"_SLOPE_cvDenseCpp", (DL_FUNC) &_SLOPE_cvDenseCpp, 4},
     {NULL, NULL, 0}

--- a/src/rcppSLOPE.cpp
+++ b/src/rcppSLOPE.cpp
@@ -2,6 +2,8 @@
 #include "slope/slope.h"
 #include "slope/threads.h"
 #include <RcppEigen.h>
+#include <bigmemory/BigMatrix.h>
+#include <bigmemory/MatrixAccessor.hpp>
 
 template<typename T>
 Rcpp::List
@@ -77,4 +79,19 @@ denseSLOPE(Eigen::MatrixXd& x,
     throw std::invalid_argument("Input matrix must not contain missing values");
   }
   return callSLOPE(x, y, control);
+}
+
+// [[Rcpp::export]]
+Rcpp::List
+bigSLOPE(SEXP x, const Eigen::MatrixXd& y, const Rcpp::List& control)
+{
+  using Eigen::Map;
+  using Eigen::MatrixXd;
+
+  Rcpp::XPtr<BigMatrix> bm_ptr(x);
+
+  Map<MatrixXd> x_map =
+    Map<MatrixXd>((double*)bm_ptr->matrix(), bm_ptr->nrow(), bm_ptr->ncol());
+
+  return callSLOPE(x_map, y, control);
 }

--- a/tests/testthat/test-bigmatrix.R
+++ b/tests/testthat/test-bigmatrix.R
@@ -1,0 +1,42 @@
+library(SLOPE)
+library(testthat)
+library(bigmemory)
+
+test_that("Bigmatrix", {
+  n <- 4
+
+  x <- diag(n)
+  y <- c(8, 6, 4, 2)
+  lambda <- c(4, 3, 2, 1)
+
+  tmp_dir <- tempdir()
+
+  x <- bigmemory::filebacked.big.matrix(
+    n,
+    n,
+    type = "double",
+    init = 0,
+    backingfile = "example.bin",
+    descriptorfile = "example.desc",
+    backingpath = tmp_dir
+  )
+
+  diag(x) <- 1
+
+  res <- SLOPE(
+    x,
+    y,
+    family = "gaussian",
+    intercept = FALSE,
+    center = FALSE,
+    scale = "none",
+    lambda = lambda / n,
+    alpha = 1
+  )
+
+  unlink(tmp_dir, recursive = TRUE)
+
+  beta <- coef(res)
+
+  expect_equal(as.vector(beta), c(4, 3, 2, 1), check.attributes = FALSE)
+})


### PR DESCRIPTION
Only for `SLOPE()` currently, but should be quite straightforward to
implement for `cvSLOPE()` too.